### PR TITLE
Most recent versions of DbgHelp have reinforced checks

### DIFF
--- a/DbgHelpUtils/symbol_engine.cpp
+++ b/DbgHelpUtils/symbol_engine.cpp
@@ -1079,7 +1079,12 @@ namespace dlg_help_utils::dbg_help
         if (pdb.is_valid())
         {
             auto const debug_module_info_size = sizeof(IMAGE_DEBUG_DIRECTORY) + cv_record_size;
-            auto const debug_module_info = std::make_unique<uint8_t[]>(debug_module_info_size);
+
+            // Most recent DbgHelp.dll now requires sizeof(IMAGE_DEBUG_DIRECTORY) + cv_record_size to be 8bytes-aligned
+            auto const mandatoryAlignment = 8;
+            auto const debug_module_info_size_aligned = (debug_module_info_size + mandatoryAlignment) & (~uint64_t(mandatoryAlignment - 1));
+
+            auto const debug_module_info = std::make_unique<uint8_t[]>(debug_module_info_size_aligned);
             auto* info = reinterpret_cast<IMAGE_DEBUG_DIRECTORY*>(debug_module_info.get());
 
             info->TimeDateStamp = module_time_stamp;
@@ -1089,6 +1094,7 @@ namespace dlg_help_utils::dbg_help
             info->Type = IMAGE_DEBUG_TYPE_CODEVIEW;
             info->AddressOfRawData = 0;
             info->PointerToRawData = sizeof(IMAGE_DEBUG_DIRECTORY);
+            info->SizeOfData = cv_record_size;
 
             memcpy(debug_module_info.get() + info->PointerToRawData, cv_record, cv_record_size);
 
@@ -1096,7 +1102,7 @@ namespace dlg_help_utils::dbg_help
             module_load_info.ssize = sizeof(module_load_info);
             module_load_info.ssig = DBHHEADER_DEBUGDIRS;
             module_load_info.data = debug_module_info.get();
-            module_load_info.size = static_cast<DWORD>(debug_module_info_size);
+            module_load_info.size = static_cast<DWORD>(debug_module_info_size_aligned);
             module_load_info.flags = 0;
 
             if (callback().symbol_load_debug())


### PR DESCRIPTION
Quite a bit of time was lost trying to understand why the code was not working on a Windows11 machine. As it turns out, newer Windows SDKs (and Win11), have changed the way DbgHelp parses the headers. After reverse-engineering the code a bit, I finally found out that what changed is that `SizeOfData` is now actually checked. 

Not only is it checked, but it does so by also making sure that each debug directory entry not only is properly aligned... but its size too. This means that for each `sizeof(IMAGE_DEBUG_DIRECTORY) + dir.SizeOfData` (it is an array) needs to be of a size aligned to 8 bytes. For future reference, the culprit is `DbgHelp.dll!ReadCallerData`.  
I think it's probably a mistake, but this is easily fixed on our side once we know about it. (Who'd have guessed, you had a 1/8 chance of having it working depending on the pdb path length!)